### PR TITLE
각 기능 별 적합한 동시성 제어 방식을 채택하고 테스트를 수행한다.

### DIFF
--- a/src/main/java/com/hhplus/io/amount/application/AmountUseCase.java
+++ b/src/main/java/com/hhplus/io/amount/application/AmountUseCase.java
@@ -32,9 +32,6 @@ public class AmountUseCase {
      */
     @Transactional
     public SaveAmountCommand saveAmount(Long userId, int updateAmount){
-        if(updateAmount < 0) {
-            throw new CoreException(ErrorType.FORBIDDEN);
-        }
         int newAmount = amountService.updateAmount(userId, updateAmount);
         return SaveAmountCommand.of(userId, newAmount);
 

--- a/src/main/java/com/hhplus/io/amount/domain/AmountInfo.java
+++ b/src/main/java/com/hhplus/io/amount/domain/AmountInfo.java
@@ -2,6 +2,9 @@ package com.hhplus.io.amount.domain;
 
 import com.hhplus.io.amount.domain.entity.Amount;
 import com.hhplus.io.amount.domain.repository.AmountRepository;
+import com.hhplus.io.support.domain.error.CoreException;
+import com.hhplus.io.support.domain.error.ErrorType;
+import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -21,15 +24,21 @@ public class AmountInfo {
     }
 
     public int updateAmount(Long userId, int updateAmount) {
+        if (updateAmount < 0) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
         Amount amount = amountRepository.getAmountByUserWithLock(userId);
         amount.saveAmount(updateAmount);
         return amount.getAmount();
     }
 
+    @Transactional
     public void payAmount(Long userId, int payment) {
         Amount amount = amountRepository.getAmountByUserWithLock(userId);
+        if (amount.getAmount() - payment < 0) {
+            throw new CoreException(ErrorType.FORBIDDEN);
+        }
         amount.payAmount(payment);
-        amount.updatePaymentDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
-
+        amount.updatePaymentDate(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/hhplus/io/amount/domain/repository/AmountRepository.java
+++ b/src/main/java/com/hhplus/io/amount/domain/repository/AmountRepository.java
@@ -8,7 +8,5 @@ public interface AmountRepository {
 
     Amount getAmountByUser(Long userId);
 
-    Amount save(Amount amount);
-
     Amount getAmountByUserWithLock(Long userId);
 }

--- a/src/main/java/com/hhplus/io/amount/persistence/AmountJpaRepository.java
+++ b/src/main/java/com/hhplus/io/amount/persistence/AmountJpaRepository.java
@@ -8,6 +8,5 @@ import org.springframework.data.jpa.repository.Lock;
 import java.util.Optional;
 
 public interface AmountJpaRepository extends JpaRepository<Amount, Long> {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Amount> findByUserId(Long userId);
 }

--- a/src/main/java/com/hhplus/io/amount/persistence/AmountRepositoryImpl.java
+++ b/src/main/java/com/hhplus/io/amount/persistence/AmountRepositoryImpl.java
@@ -2,14 +2,13 @@ package com.hhplus.io.amount.persistence;
 
 import com.hhplus.io.amount.domain.repository.AmountRepository;
 import com.hhplus.io.amount.domain.entity.Amount;
-import com.hhplus.io.support.domain.error.CoreException;
-import com.hhplus.io.support.domain.error.ErrorType;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.LockModeType;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+
+import static com.hhplus.io.amount.domain.entity.QAmount.amount1;
 
 @Repository
 public class AmountRepositoryImpl implements AmountRepository {
@@ -30,13 +29,11 @@ public class AmountRepositoryImpl implements AmountRepository {
     }
 
     @Override
-    public Amount save(Amount amount) {
-        return jpaRepository.save(amount);
-    }
-
-    @Override
     public Amount getAmountByUserWithLock(Long userId) {
-        Optional<Amount> optionalAmount = jpaRepository.findByUserId(userId);
-        return optionalAmount.orElse(null);
+        return jpaQueryFactory
+                .selectFrom(amount1)
+                .where(amount1.userId.eq(userId))
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .fetchOne();
     }
 }

--- a/src/main/java/com/hhplus/io/concert/domain/SeatInfo.java
+++ b/src/main/java/com/hhplus/io/concert/domain/SeatInfo.java
@@ -28,7 +28,7 @@ public class SeatInfo {
     }
 
     public void updateStatusAndReservationTime(Long seatId, SeatStatus fromStatus, SeatStatus updateStatus, LocalDateTime updateTime) {
-        Seat seat = seatRepository.getSeatWithLock(seatId);
+        Seat seat = seatRepository.getSeat(seatId);
         if (seat == null) {
             throw new CoreException(ErrorType.SEAT_NOT_FOUND);
         }

--- a/src/main/java/com/hhplus/io/concert/domain/entity/Seat.java
+++ b/src/main/java/com/hhplus/io/concert/domain/entity/Seat.java
@@ -41,12 +41,20 @@ public class Seat extends BaseEntity {
     @Comment("좌석별 티켓 가격")
     private int ticketPrice;
 
+    @Version
+    @Column(name = "version")
+    @Comment("[낙관적락] 버전 관리 컬럼")
+    private int version;
+
     @Column(name = "reservation_time")
     @Comment("임시예약시간")
     private LocalDateTime reservationTime;
 
     public void updateSeatStatus(String status) {
         this.status = status;
+    }
+    public void setVersion(int version) {
+        this.version = version;
     }
 
     public void updateReservationTime(LocalDateTime updateTime) {

--- a/src/main/java/com/hhplus/io/concert/persistence/SeatJpaRepository.java
+++ b/src/main/java/com/hhplus/io/concert/persistence/SeatJpaRepository.java
@@ -12,7 +12,5 @@ import java.util.Optional;
 @Repository
 public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
     List<Seat> findAllByConcertIdAndStatus(Long concertDateId, String status);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Seat> findBySeatId(Long seatId);
 }

--- a/src/test/java/com/hhplus/io/amount/application/AmountUseCaseTest.java
+++ b/src/test/java/com/hhplus/io/amount/application/AmountUseCaseTest.java
@@ -1,29 +1,31 @@
 package com.hhplus.io.amount.application;
 
 import com.hhplus.io.AcceptanceTest;
-import com.hhplus.io.DatabaseCleanUp;
 import com.hhplus.io.amount.domain.entity.Amount;
 import com.hhplus.io.amount.persistence.AmountJpaRepository;
+import com.hhplus.io.amount.service.AmountService;
 import com.hhplus.io.support.domain.error.CoreException;
 import com.hhplus.io.support.domain.error.ErrorType;
 import com.hhplus.io.usertoken.domain.entity.User;
 import com.hhplus.io.usertoken.persistence.UserJpaRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class AmountUseCaseTest  extends AcceptanceTest {
+@Transactional
+class AmountIntegrationTest extends AcceptanceTest {
 
     @Autowired
     private AmountUseCase amountUseCase;
+    @Autowired
+    private AmountService amountService;
     @Autowired
     private AmountJpaRepository amountRepository;
     @Autowired
@@ -106,41 +108,109 @@ class AmountUseCaseTest  extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("잔액 충전 동시성 테스트")
-        void 동일_유저가_잔액충전을_동시에_실행할_경우() throws InterruptedException, ExecutionException {
+        @DisplayName("[비관적 락] 잔액 충전 동시성 테스트")
+        void 동일_유저가_잔액충전을_동시에_실행할_경우() throws InterruptedException {
             //given
+            long startTime = System.nanoTime();
             Long userId = 1L;
             int updateAmount = 100;
             int threadCount = 10;
 
-            ExecutorService executor = Executors.newFixedThreadPool(threadCount); // 10개의 스레드로 테스트
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            List<SaveAmountCommand> commands = new ArrayList<>();
 
-            //when
-            List<Callable<SaveAmountCommand>> tasks = new ArrayList<>();
             for (int i = 0; i < threadCount; i++) {
-                tasks.add(() -> amountUseCase.saveAmount(userId, updateAmount));
+                executorService.submit(() -> {
+                    try {
+                        SaveAmountCommand command = amountUseCase.saveAmount(userId, updateAmount);
+                        commands.add(command);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
             }
+            latch.await();
+            executorService.shutdown();
 
-            List<Future<SaveAmountCommand>> futures = executor.invokeAll(tasks);
-            executor.shutdown();
+            assertNotNull(commands.get(0));
+            assertEquals(10000+updateAmount, commands.get(0).amount(), "잔액이 한번만 충전되어야 함");
 
-            //then
-            int totalAmount = 0;
-            for (Future<SaveAmountCommand> future : futures) {
-                SaveAmountCommand result = future.get();
-                assertNotNull(result);
-                int saveAmount = result.amount() - 10000;
-                totalAmount += saveAmount;
-            }
-            assertEquals(100*threadCount, totalAmount); //동시 충전 시도한 충전 금액
+            long endTime = System.nanoTime();
+            long duration = endTime - startTime;
 
-            amountRepository.findByUserId(userId).ifPresent(amount -> {
-                //실제 충전은 1회만
-                assertEquals(10000+updateAmount, amount.getAmount());
-            });
+            System.out.println("실행시간 : " + duration + " 나노초");
 
         }
 
+    }
+
+    @Nested
+    @DisplayName("잔액 사용")
+    class payAmount {
+
+        @Test
+        void 잔액_사용_성공() {
+            //given
+            Long userId = 1L;
+            int payAmount = 10000;
+
+            //when
+            amountService.pay(userId, payAmount);
+
+            //then
+            Amount amount = amountRepository.findByUserId(userId).orElseThrow();
+            assertEquals(0, amount.getAmount());
+
+        }
+
+        @Test
+        void 기존_잔액보다_큰_금액_결제시_실패() {
+            //given
+            Long userId = 1L;
+            int payAmount = 15000;
+
+            //when
+            CoreException exception = assertThrows(CoreException.class, () -> amountService.pay(userId, payAmount));
+
+            //then
+            assertEquals(ErrorType.FORBIDDEN, exception.getErrorType());
+
+        }
+
+        @Test
+        @DisplayName("[비관적 락] 결제 동시성 테스트")
+        void 동일_유저가_동시에_여러번_결제를_하는_경우() throws InterruptedException {
+            //given
+            long startTime = System.nanoTime();
+            Long userId = 1L;
+            int payAmount = 10000;
+            int threadCount = 10;
+
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        amountService.pay(userId, payAmount);
+                    } catch (Exception e) {
+                        System.out.println(e.getMessage());
+                    }
+                });
+                latch.countDown();
+            }
+            latch.await();
+            executorService.shutdown();
+
+            Amount amount = amountRepository.findByUserId(userId).orElseThrow();
+            assertEquals(0, amount.getAmount(), "잔액 결제는 1회만 되어야 한다.");
+
+            long endTime = System.nanoTime();
+            long duration = endTime - startTime;
+
+            System.out.println("실행시간 : " + duration + " 나노초");
+        }
     }
 
 }


### PR DESCRIPTION
[DB lock을 활용한 동시성 제어 보고서](https://noname-w-right.tistory.com/48)
### TODO
- 기능 별 동시성 제어 방식 테스트
- 기능 별 적합한 동시성 제어 방식 채택
- 적용 및 테스트

### 작업 내용
- 좌석 엔티티에 낙관적 락 적용 [fb48376](https://github.com/maiorem/ticket-reservation/pull/33/commits/fb48376fcd04136bd9fc28dba0c2fdd49037e2c5)
- 잔액 충전/사용 쿼리에 비관적 락 적용 [b19f7b0](https://github.com/maiorem/ticket-reservation/pull/33/commits/b19f7b0ab13ef301b1b4adc9c4a64ddc44043e84)
- 잔액 충전/사용 동시성 테스트 수정 [3dcff27](https://github.com/maiorem/ticket-reservation/pull/33/commits/3dcff27e991f5056a769c07ca6331ed896896d8f)

### 리뷰 포인트
- 낙관적 락은 컬럼에 바로 걸고 setVersion을 통해 버전이 업데이트 되는 것을 확인했는데, 만약에 잔액을 충전하고 사용하는 별개의 로직에서 하나는 비관적 락을 걸고 하나는 낙관적 락을 걸고 싶다면 엔티티를 따로 써야 할까요? 비관적 락은 락이 걸리는 쿼리를 따로 사용하면 되는데 낙관적 락을 따로 사용하는 방법을 모르겠습니다. 같은 도메인인데 락 때문에 엔티티를 나눠야 할까요?