### PR TITLE
STEP17 : 카프카 연동 및 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,12 +67,18 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers:1.20.3'
     testImplementation 'org.testcontainers:junit-jupiter:1.20.3'
     testImplementation 'org.testcontainers:mysql:1.20.3'
+    testImplementation "com.redis.testcontainers:testcontainers-redis-junit:1.6.4"
+    testImplementation "org.testcontainers:kafka:1.20.1"
 
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // redisson
     implementation 'org.redisson:redisson-spring-boot-starter:3.37.0'
+
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
 }
 
 tasks.named('test') {

--- a/docker/kafka/docker-compose.yml
+++ b/docker/kafka/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-kafka:latest
+    hostname: broker
+    container_name: broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 101
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0

--- a/docker/kafka/kafka_excute.md
+++ b/docker/kafka/kafka_excute.md
@@ -1,0 +1,2 @@
+### 카프카 실행 방법
+- docker-compose -f docker/kafka/docker-compose.yml up

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   mysql:
     image: mysql:8.0
     ports:
-      - "3307:3306"
+      - "3308:3306"
     environment:
       - MYSQL_DATABASE=concert
       - MYSQL_ROOT_PASSWORD=hhplus
@@ -43,5 +43,31 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
 
-volumes:
-  mysql-data:
+  zookeeper_1:
+    image: confluentinc/cp-zookeeper:latest
+    hostname: zookeeper_1
+    container_name: zookeeper_1
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka_1:
+    image: confluentinc/cp-kafka:latest
+    hostname: kafka_1
+    container_name: kafka_1
+    depends_on:
+      - zookeeper_1
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 101
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper_1:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka_1:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0

--- a/src/main/java/com/hhplus/io/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/hhplus/io/common/config/KafkaConsumerConfig.java
@@ -1,0 +1,37 @@
+package com.hhplus.io.common.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(config);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+}

--- a/src/main/java/com/hhplus/io/common/config/KafkaProducerConfig.java
+++ b/src/main/java/com/hhplus/io/common/config/KafkaProducerConfig.java
@@ -1,0 +1,35 @@
+package com.hhplus.io.common.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -28,6 +28,8 @@ spring:
       host: host.docker.internal
   cache:
     type: redis
+  kafka:
+    bootstrap-servers: host.docker.internal:9092
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,6 +28,9 @@ spring:
   cache:
     type: redis
 
+  kafka:
+    bootstrap-servers: localhost:9092
+
 logging:
   level:
     org.hibernate.sql : DEBUG

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -5,9 +5,3 @@ spring:
   datasource:
     hikari:
       connection-timeout: 10000
-  data:
-    redis:
-      port: 6379
-      host: localhost
-  cache:
-    type: redis

--- a/src/test/java/com/hhplus/io/kafka/KafkaConnectorTest.java
+++ b/src/test/java/com/hhplus/io/kafka/KafkaConnectorTest.java
@@ -1,0 +1,37 @@
+package com.hhplus.io.kafka;
+
+import com.hhplus.io.testcontainer.AcceptanceTest;
+import groovy.util.logging.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+@Slf4j
+public class KafkaConnectorTest extends AcceptanceTest {
+
+    @Autowired
+    private KafkaProducerTest kafkaProducerTest;
+    @Autowired
+    private KafkaConsumerTest kafkaConsumerTest;
+
+    @Test
+    @DisplayName("Kafka 연동 테스트")
+    void kafkaTest() {
+
+        int cnt = 10;
+        String topic = "topic_test";
+        for (int i = 0; i < cnt; i++) {
+            kafkaProducerTest.send(topic, "Producer Sending Message : " + (i + 1));
+        }
+
+        await().pollDelay(2, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(kafkaConsumerTest.getMessageList())
+                        .hasSize(cnt));
+    }
+}

--- a/src/test/java/com/hhplus/io/kafka/KafkaConsumerTest.java
+++ b/src/test/java/com/hhplus/io/kafka/KafkaConsumerTest.java
@@ -1,0 +1,29 @@
+package com.hhplus.io.kafka;
+
+import groovy.util.logging.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+
+@Component
+public class KafkaConsumerTest {
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaConsumerTest.class);
+    private final List<String> messageList = new ArrayList<>();
+
+    @KafkaListener(topics = "topic_test", groupId = "group_test")
+    public void consume(String message) {
+        log.info("Consumer Received message : {}", message);
+        messageList.add(message);
+    }
+
+    public List<String> getMessageList() {
+        return messageList;
+    }
+}

--- a/src/test/java/com/hhplus/io/kafka/KafkaProducerTest.java
+++ b/src/test/java/com/hhplus/io/kafka/KafkaProducerTest.java
@@ -1,0 +1,18 @@
+package com.hhplus.io.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaProducerTest {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public KafkaProducerTest(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void send(String topic, String message) {
+        kafkaTemplate.send(topic, message);
+    }
+}


### PR DESCRIPTION
### TODO 
- 카프카 설정 및 연동
- 카프카 연동 테스트

### 작업내역
- 카프카 의존성 설정 : [294ab65](https://github.com/maiorem/ticket-reservation/pull/51/commits/294ab659b66c4557b5b0f050ed9676c1713486fb)
- 도커 컴포즈 구성 : [048a058](https://github.com/maiorem/ticket-reservation/pull/51/commits/048a058ce2722c565df8a1235fa4582e5dead715)
- 카프카 Producer / Consumer Config 추가 : [fb46515](https://github.com/maiorem/ticket-reservation/pull/51/commits/fb465151d51bc5edcd558482fb24df29156d25e5)
- 테스트 컨테이너에 카프카 설정 추가 : [513a0b6](https://github.com/maiorem/ticket-reservation/pull/51/commits/513a0b6c20cfcd8ca90696a7a257bd23cee17e4c)
- 연동 테스트 : [714d8a0](https://github.com/maiorem/ticket-reservation/pull/51/commits/714d8a0e6d596368d799c1e7aaf693c8be2d22e8)

### 테스트 
![image](https://github.com/user-attachments/assets/c36cff72-65ec-424d-820f-bf72053304d7)

브로커가 Producer로 부터 가져온 토픽과 메시지를 발행하면
![image](https://github.com/user-attachments/assets/81ccc884-044c-4ce5-a600-e91b3cfb1ee7)

Consumer가 토픽과 메시지를 받음
![image](https://github.com/user-attachments/assets/b2f7b8da-7a76-462f-9da3-5d9b3339b399)

결과 : 
실제 실행 순서는 컨슈머의 consume() 가 브로커 send() 를 당겨옴(polling)
![image](https://github.com/user-attachments/assets/f227151a-c9d4-4560-9504-8df0752947d6)

![image](https://github.com/user-attachments/assets/12ec22e4-d8a5-4992-b3db-501c1de5aa8b)

